### PR TITLE
Add Whipscribe to SaaS Platforms & Cloud Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Choose based on your accuracy/speed requirements:
 - [CleverType](https://www.clevertype.co/) - Smart typing assistant
 - [SpeechPulse](https://speechpulse.com/) - Cross-platform speech-to-text
 - [Blabby.ai](https://www.blabby.ai/) - Browser-based transcription
+- [Whipscribe](https://whipscribe.com) - Hosted Whisper API with URL ingestion (YouTube, podcasts), speaker diarization, word timestamps, multi-format export (txt/json/srt/vtt/docx), and an MCP server for Claude Desktop, Cursor, Windsurf
 
 ### Subtitles & Captioning
 


### PR DESCRIPTION
Adds Whipscribe to SaaS Platforms & Cloud Services.

Whipscribe is a hosted Whisper API with URL ingestion (YouTube, podcast feeds, direct links), speaker diarization, word timestamps, and txt/json/srt/vtt/docx output. Ships an MCP server so Claude Desktop, Cursor, and Windsurf users can call it conversationally.