### PR TITLE
Add OpenQuack

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Applications that work on Linux, macOS, and Windows:
 - **[OpenSuperWhisper](https://github.com/Starmel/OpenSuperWhisper)** ![GitHub stars](https://img.shields.io/github/stars/Starmel/OpenSuperWhisper?style=flat-square) - Open-source Mac app
 - **[WhisperKit](https://github.com/argmaxinc/WhisperKit)** ![GitHub stars](https://img.shields.io/github/stars/argmaxinc/WhisperKit?style=flat-square) - Native macOS implementation
 - **[Careless Whisper](https://carelesswhisper.app/)** - Lightweight transcription app
+- **[OpenQuack](https://github.com/larryxiao/openquack)** ![GitHub stars](https://img.shields.io/github/stars/larryxiao/openquack?style=flat-square) - Open-source local-only Mac dictation menu bar app using WhisperKit; paste at cursor.
 
 #### System Integration
 - **[ollama-voice-mac](https://github.com/apeatling/ollama-voice-mac)** ![GitHub stars](https://img.shields.io/github/stars/apeatling/ollama-voice-mac?style=flat-square) - Voice interface for Ollama


### PR DESCRIPTION
Adds OpenQuack — privacy-first local voice dictation menu bar app for macOS, MIT-licensed, ~8 MB Swift binary running WhisperKit on Apple Silicon — to the macOS > Desktop Applications subsection.

- Repo: https://github.com/larryxiao/openquack
- License: MIT
- Format: matched to existing entries (bold link + GitHub stars badge + short description).
- Position: appended to the macOS Desktop Applications subsection (existing order is additive, not alphabetical).

Thanks for maintaining the list!