### PR TITLE
Add dictate.app — Windows push-to-talk dictation via Groq Whisper

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Applications that work on Linux, macOS, and Windows:
 
 #### Desktop Applications
 - **[AI Transcription](https://apps.microsoft.com/detail/9p7f1j2svk3g)** - Microsoft Store app
+- **[dictate.app](https://dictate-app.pages.dev)** - Push-to-talk via Groq Whisper. ~200ms latency, auto-pastes at cursor, 7-day trial.
 - **[Whisper Typing for Windows](https://whispertyping.com/download)** - Desktop voice typing
 
 #### System Integration


### PR DESCRIPTION
**dictate.app** is a Windows push-to-talk voice dictation app using Groq Whisper (not OpenAI Whisper, but the same model architecture via Groq API).

- ~200ms transcription latency via Groq
- Auto-pastes text at cursor position (any app, any text field)
- Global hotkey, remappable
- 7-day free trial
- https://dictate-app.pages.dev

Fits under Windows Desktop Applications alongside the existing Windows entries.