### PR TITLE
Add Dictivo (macOS desktop dictation app)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Applications that work on Linux, macOS, and Windows:
 - **[OpenSuperWhisper](https://github.com/Starmel/OpenSuperWhisper)** ![GitHub stars](https://img.shields.io/github/stars/Starmel/OpenSuperWhisper?style=flat-square) - Open-source Mac app
 - **[WhisperKit](https://github.com/argmaxinc/WhisperKit)** ![GitHub stars](https://img.shields.io/github/stars/argmaxinc/WhisperKit?style=flat-square) - Native macOS implementation
 - **[Careless Whisper](https://carelesswhisper.app/)** - Lightweight transcription app
+- **[Dictivo](https://dictivo.app/)** - Local-first dictation app running whisper.cpp on-device with hardware-aware model selection
 
 #### System Integration
 - **[ollama-voice-mac](https://github.com/apeatling/ollama-voice-mac)** ![GitHub stars](https://img.shields.io/github/stars/apeatling/ollama-voice-mac?style=flat-square) - Voice interface for Ollama


### PR DESCRIPTION
Adds Dictivo to the macOS → Desktop Applications section.

Dictivo is a local-first Mac dictation app built on whisper.cpp. It benchmarks the user's hardware on first launch and maps Whisper models to Fast/Medium/Quality tiers with predicted real-time factors, so users know up front which model their machine can run. Optional cloud mode exists but on-device is the default.

Disclosure: I'm the developer. Entry follows the existing closed-source format (like SuperWhisper - no stars badge). Happy to adjust wording or placement.

Site: https://dictivo.app · Benchmark method: https://dictivo.app/guides/mac-dictation-benchmark-method/