### PR TITLE
Add WhisperPress (Windows, offline push-to-talk dictation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Applications that work on Linux, macOS, and Windows:
 #### Desktop Applications
 - **[AI Transcription](https://apps.microsoft.com/detail/9p7f1j2svk3g)** - Microsoft Store app
 - **[Whisper Typing for Windows](https://whispertyping.com/download)** - Desktop voice typing
+- **[WhisperPress](https://github.com/b84330808/whisperpress)** ![GitHub stars](https://img.shields.io/github/stars/b84330808/whisperpress?style=flat-square) - Offline push-to-talk voice typing and voice notes, powered by whisper.cpp
 
 #### System Integration
 - **[WinWhisper](https://github.com/GewoonJaap/WinWhisper)** ![GitHub stars](https://img.shields.io/github/stars/GewoonJaap/WinWhisper?style=flat-square) - System-wide hotkey support


### PR DESCRIPTION
Adds WhisperPress under Windows > Desktop Applications.

MIT-licensed, fully offline dictation app built on whisper.cpp: hold a hotkey, speak, release - the transcript is typed into whatever app the cursor is in. Also does meeting transcription via system-audio loopback, audio file imports, voice notes history, deterministic Traditional/Simplified Chinese output (OpenCC), and SRT export. UI in English / Traditional Chinese / Japanese.

Repo with demo video: https://github.com/b84330808/whisperpress