### PR TITLE
Add Tania Dictée (Windows desktop dictation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Applications that work on Linux, macOS, and Windows:
 
 #### Desktop Applications
 - **[AI Transcription](https://apps.microsoft.com/detail/9p7f1j2svk3g)** - Microsoft Store app
+- **[Tania Dictée](https://github.com/elboKazQC/tania-dictee)** - Push-to-talk dictation (F6), pastes directly into the focused app. Runs Whisper offline, no cloud. Handles French-Quebec franglais. MIT.
 - **[Whisper Typing for Windows](https://whispertyping.com/download)** - Desktop voice typing
 
 #### System Integration


### PR DESCRIPTION
Adds **Tania Dictée** under *By Platform > Windows > Desktop Applications*.

It's an open-source (MIT) push-to-talk dictation tool for Windows built on Whisper-large-v3, running fully offline (no cloud, no API). F6 hotkey, pastes straight into the focused window. Its niche angle is French-Quebec "franglais" (mixed FR/EN speech) that most dictation tools normalize away.

- Repo: https://github.com/elboKazQC/tania-dictee
- License: MIT
- Stack: faster-whisper + sounddevice + keyboard + pyperclip

Honest note: it's early/alpha and Windows-only for now. Happy to adjust the wording or placement if you'd prefer it elsewhere.