### PR TITLE
Add Whisper Vox (Windows system integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Applications that work on Linux, macOS, and Windows:
 
 #### System Integration
 - **[WinWhisper](https://github.com/GewoonJaap/WinWhisper)** ![GitHub stars](https://img.shields.io/github/stars/GewoonJaap/WinWhisper?style=flat-square) - System-wide hotkey support
+- **[Whisper Vox](https://github.com/whisper-vox/whisper-vox)** ![GitHub stars](https://img.shields.io/github/stars/whisper-vox/whisper-vox?style=flat-square) - Hold-a-key dictation that types into any app (GPL-3.0, system tray, 99 languages)
 
 ---
 


### PR DESCRIPTION
Adds Whisper Vox — a free, open-source (GPL-3.0) hold-to-dictate voice typing app for Windows. Hold a hotkey, speak, release, and the text is typed into whatever app is focused (browser, email, Office, chat, IDEs, AI assistants). Runs from the system tray, 99 languages with auto-detection, uses Whisper via the OpenAI/Groq API.

Repo: https://github.com/whisper-vox/whisper-vox