### PR TITLE
Add VoxFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Choose based on your accuracy/speed requirements:
 **macOS:**
 - [SuperWhisper](#superwhisper) - Premium Mac voice-to-text app
 - [OpenSuperWhisper](#opensuperwhisper) - Open-source Mac app
+- [VoxFlow](https://github.com/xingbofeng/VoxFlow) - Open-source voice input workbench with local and cloud ASR.
 - [WhisperKit](#whisperkit) - Native macOS implementation
 
 **Windows:**
@@ -204,6 +205,7 @@ Applications that work on Linux, macOS, and Windows:
 #### Desktop Applications
 - **[SuperWhisper](https://superwhisper.com/)** - Premium Mac voice-to-text app
 - **[OpenSuperWhisper](https://github.com/Starmel/OpenSuperWhisper)** ![GitHub stars](https://img.shields.io/github/stars/Starmel/OpenSuperWhisper?style=flat-square) - Open-source Mac app
+- **[VoxFlow](https://github.com/xingbofeng/VoxFlow)** ![GitHub stars](https://img.shields.io/github/stars/xingbofeng/VoxFlow?style=flat-square) - Open-source voice input workbench with local and cloud ASR.
 - **[WhisperKit](https://github.com/argmaxinc/WhisperKit)** ![GitHub stars](https://img.shields.io/github/stars/argmaxinc/WhisperKit?style=flat-square) - Native macOS implementation
 - **[Careless Whisper](https://carelesswhisper.app/)** - Lightweight transcription app
 


### PR DESCRIPTION
## Summary

- Added VoxFlow to the macOS voice typing list.
- Added VoxFlow to the macOS desktop applications section.

VoxFlow is an open-source macOS voice input workbench with local and cloud ASR.

## Links

- Repository: https://github.com/xingbofeng/VoxFlow
- Website: https://xingbofeng.github.io/VoxFlow/
- Latest release: https://github.com/xingbofeng/VoxFlow/releases/tag/v1.8.2
