### PR TITLE
Add Off Grid AI Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Applications that work on Linux, macOS, and Windows:
 - **[OpenSuperWhisper](https://github.com/Starmel/OpenSuperWhisper)** ![GitHub stars](https://img.shields.io/github/stars/Starmel/OpenSuperWhisper?style=flat-square) - Open-source Mac app
 - **[WhisperKit](https://github.com/argmaxinc/WhisperKit)** ![GitHub stars](https://img.shields.io/github/stars/argmaxinc/WhisperKit?style=flat-square) - Native macOS implementation
 - **[Careless Whisper](https://carelesswhisper.app/)** - Lightweight transcription app
+- **[Off Grid AI Desktop](https://github.com/off-grid-ai/off-grid-ai-desktop)** ![GitHub stars](https://img.shields.io/github/stars/off-grid-ai/off-grid-ai-desktop?style=flat-square) - Open-source (AGPL-3.0) macOS app with on-device voice dictation powered by whisper.cpp that types transcribed speech into any app; part of a fully-local AI suite (LLM chat, image gen, RAG)
 
 #### System Integration
 - **[ollama-voice-mac](https://github.com/apeatling/ollama-voice-mac)** ![GitHub stars](https://img.shields.io/github/stars/apeatling/ollama-voice-mac?style=flat-square) - Voice interface for Ollama


### PR DESCRIPTION
Adds Off Grid AI Desktop to the macOS Desktop Applications list.

Off Grid AI Desktop is an open-source (AGPL-3.0) macOS app with on-device voice dictation powered by whisper.cpp that types transcribed speech into any app. It runs fully locally as part of a broader on-device AI suite (LLM chat, image generation, RAG).

- Repo: https://github.com/off-grid-ai/off-grid-ai-desktop
- Site: https://getoffgridai.co/desktop

Entry matches the surrounding format (bold link, GitHub stars badge, short description).

Disclosure: I'm involved with the project.