### PR TITLE
Add AI Dictation to Windows voice tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Applications that work on Linux, macOS, and Windows:
 - **[Whisper Typing for Windows](https://whispertyping.com/download)** - Desktop voice typing
 
 #### System Integration
+- **[AI Dictation](https://github.com/writingmate/aidictation)** ![GitHub stars](https://img.shields.io/github/stars/writingmate/aidictation?style=flat-square) - Windows voice typing with a global shortcut and offline Whisper via Whisper.net; optional cloud transcription and cleanup
 - **[WinWhisper](https://github.com/GewoonJaap/WinWhisper)** ![GitHub stars](https://img.shields.io/github/stars/GewoonJaap/WinWhisper?style=flat-square) - System-wide hotkey support
 
 ---


### PR DESCRIPTION
## Summary

Adds AI Dictation to the Windows System Integration section using only the verified Windows implementation: a global voice-typing shortcut and offline Whisper through Whisper.net. Optional cloud transcription and cleanup are described separately.

## Verification

- Current source and MIT license: https://github.com/writingmate/aidictation
- Windows local implementation: AIDictation.Windows/AIDictation/Services/WhisperLocalService.cs
- Current product site: https://aidictation.com
- Current releases and repository activity verified.

## Disclosure

I am affiliated with AI Dictation and am submitting it openly rather than presenting this as an independent recommendation. The entry and PR text were prepared with AI assistance and checked against the current source and this list's format.