### PR TITLE
Add YazSes (cross-platform offline dictation daemon)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Applications that work on Linux, macOS, and Windows:
 | [whisper-ui](https://github.com/schnoddelbotz/whisper-ui) | ![GitHub stars](https://img.shields.io/github/stars/schnoddelbotz/whisper-ui?style=flat-square) | Cross-platform desktop UI |
 | [whisper_dictation](https://github.com/themanyone/whisper_dictation) | ![GitHub stars](https://img.shields.io/github/stars/themanyone/whisper_dictation?style=flat-square) | Voice dictation tool |
 | [WhisperGUI](https://github.com/ADT109119/WhisperGUI) | ![GitHub stars](https://img.shields.io/github/stars/ADT109119/WhisperGUI?style=flat-square) | Simple GUI |
+| [YazSes](https://github.com/MSKazemi/yazses) | ![GitHub stars](https://img.shields.io/github/stars/MSKazemi/yazses?style=flat-square) | Offline hold-to-talk dictation daemon with voice commands and speaker-labelled meeting transcription |
 
 ### Linux
 


### PR DESCRIPTION
Adds [YazSes](https://github.com/MSKazemi/yazses) to **Cross-Platform Desktop Applications** — one row, matching the existing table format.

It's a hold-to-talk dictation daemon built on **faster-whisper**: hold a key, speak, release, and the text is typed into whatever window has focus. Runs fully on-device — no cloud, no API key, no account. Linux (X11 and Wayland), macOS and Windows, Apache-2.0.

Beyond plain dictation it also does voice commands, offline file transcription, and whole-meeting capture with speaker labels.

Install paths that already exist, if it helps you verify it is usable rather than a stub: [PyPI](https://pypi.org/project/yazses/), [Snap Store](https://snapcraft.io/yazses) (amd64 + arm64), a signed APT repo, and tagged releases with `.deb`/`.dmg`/`.exe` (currently v2.17.0). There is also a preprint describing the design ([arXiv:2607.28878](https://arxiv.org/abs/2607.28878)).

Placed it at the end of the table rather than guessing at an ordering, since the existing rows do not look strictly alphabetical — happy to move it if you'd prefer somewhere specific, or to add it under **Linux → System Integration** instead if the cross-platform table is meant for GUI apps only.