### PR TITLE
Add JQSubtitle to Subtitles & Captioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Generate subtitles and captions for videos:
 - **[whisper-subs](https://github.com/GhostNaN/whisper-subs)** ![GitHub stars](https://img.shields.io/github/stars/GhostNaN/whisper-subs?style=flat-square) - CLI for adding subtitles to videos
 - **[whisply](https://github.com/tsmdt/whisply)** ![GitHub stars](https://img.shields.io/github/stars/tsmdt/whisply?style=flat-square) - Automatic subtitle generation (Linux)
 - **[template-tiktok](https://github.com/remotion-dev/template-tiktok)** ![GitHub stars](https://img.shields.io/github/stars/remotion-dev/template-tiktok?style=flat-square) - TikTok-style captioning with Remotion
+- **[JQSubtitle](https://github.com/i3luegirl/jqsubtitle)** ![GitHub stars](https://img.shields.io/github/stars/i3luegirl/jqsubtitle?style=flat-square) - One-click SRT + SMI subtitles on Windows. Rebuilds lines from word-level timings rather than Whisper's segment boundaries, and translates into 15 languages. Free with a Gemini key, or fully offline via Ollama
 
 ### Meeting & Productivity
 


### PR DESCRIPTION
Adding my own project, so flagging that up front.

**[JQSubtitle](https://github.com/i3luegirl/jqsubtitle)** — MIT, Windows GUI, one-line PowerShell installer that pulls in Python if it is missing.

It uses faster-whisper large-v3 with word-level timestamps and rebuilds the subtitle lines from those timings rather than trusting Whisper's segment boundaries, which is the part that makes run-on lines and mid-sentence cuts go away. Optional correction and translation into 15 languages through Gemini (free key), Claude, or a local model via Ollama. Writes SMI alongside SRT for players that expect it.

Placed it in **Subtitles & Captioning** since that is where it fits — the existing entries there are mostly CLI or editor tools, and this is a batch GUI aimed at people with a folder of videos rather than a single file.

Happy to move it, reword the description, or drop it if it is not a fit for the list.