### PR TITLE
Add Plainsay

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Choose based on your accuracy/speed requirements:
 **macOS:**
 - [SuperWhisper](#superwhisper) - Premium Mac voice-to-text app
 - [OpenSuperWhisper](#opensuperwhisper) - Open-source Mac app
+- [Plainsay](#plainsay) - On-device Mac dictation
 - [WhisperKit](#whisperkit) - Native macOS implementation
 
 **Windows:**
@@ -204,6 +205,7 @@ Applications that work on Linux, macOS, and Windows:
 #### Desktop Applications
 - **[SuperWhisper](https://superwhisper.com/)** - Premium Mac voice-to-text app
 - **[OpenSuperWhisper](https://github.com/Starmel/OpenSuperWhisper)** ![GitHub stars](https://img.shields.io/github/stars/Starmel/OpenSuperWhisper?style=flat-square) - Open-source Mac app
+- **[Plainsay](https://github.com/conrader/plainsay)** ![GitHub stars](https://img.shields.io/github/stars/conrader/plainsay?style=flat-square) - On-device dictation with Whisper or Parakeet
 - **[WhisperKit](https://github.com/argmaxinc/WhisperKit)** ![GitHub stars](https://img.shields.io/github/stars/argmaxinc/WhisperKit?style=flat-square) - Native macOS implementation
 - **[Careless Whisper](https://carelesswhisper.app/)** - Lightweight transcription app
 


### PR DESCRIPTION
Adds [Plainsay](https://github.com/conrader/plainsay) to the macOS entries, in both the Voice Typing & Dictation quick list and the macOS → Desktop Applications section, matching the surrounding format.

Plainsay is an MIT-licensed native macOS dictation app (Swift/SwiftUI, menu bar). It transcribes on-device with Whisper (via WhisperKit) or Parakeet TDT, so audio does not leave the machine in its default Local mode. Runs on macOS 14+, 12 MB download.

Disclosure: I work on Plainsay. Happy to adjust the wording or drop it if it is not a fit.