### PR TITLE
Add OpenVoiceFlow for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Choose based on your accuracy/speed requirements:
 - [voice-typing-linux](#voice-typing-linux) - Voice typing integration
 
 **macOS:**
+- [OpenVoiceFlow](https://github.com/shimoverse/openvoiceflow) - On-device voice dictation
 - [SuperWhisper](#superwhisper) - Premium Mac voice-to-text app
 - [OpenSuperWhisper](#opensuperwhisper) - Open-source Mac app
 - [WhisperKit](#whisperkit) - Native macOS implementation
@@ -202,6 +203,7 @@ Applications that work on Linux, macOS, and Windows:
 ### macOS
 
 #### Desktop Applications
+- **[OpenVoiceFlow](https://github.com/shimoverse/openvoiceflow)** ![GitHub stars](https://img.shields.io/github/stars/shimoverse/openvoiceflow?style=flat-square) - On-device voice dictation with local transcription and optional text cleanup
 - **[SuperWhisper](https://superwhisper.com/)** - Premium Mac voice-to-text app
 - **[OpenSuperWhisper](https://github.com/Starmel/OpenSuperWhisper)** ![GitHub stars](https://img.shields.io/github/stars/Starmel/OpenSuperWhisper?style=flat-square) - Open-source Mac app
 - **[WhisperKit](https://github.com/argmaxinc/WhisperKit)** ![GitHub stars](https://img.shields.io/github/stars/argmaxinc/WhisperKit?style=flat-square) - Native macOS implementation


### PR DESCRIPTION
Add OpenVoiceFlow to the macOS voice-typing and desktop-application sections.

OpenVoiceFlow is a free, MIT-licensed macOS dictation app that runs Whisper transcription on-device and can optionally clean up the resulting text.

Project: https://github.com/shimoverse/openvoiceflow

This is a self-submission from the project maintainer.