### PR TITLE
Add WhisPaste

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Choose based on your accuracy/speed requirements:
 - [Buzz](#buzz) - Feature-rich desktop app
 - [whisper-writer](#whisper-writer) - System-wide voice-to-text
 - [whisper-dictation](#whisper-dictation) - Dictation application
+- [WhisPaste](#whispaste) - System-wide hotkey dictation, pastes at the cursor
 
 **Linux:**
 - [nerd-dictation](#nerd-dictation) - Hackable offline speech-to-text
@@ -163,6 +164,7 @@ Applications that work on Linux, macOS, and Windows:
 | [whisper-ui](https://github.com/schnoddelbotz/whisper-ui) | ![GitHub stars](https://img.shields.io/github/stars/schnoddelbotz/whisper-ui?style=flat-square) | Cross-platform desktop UI |
 | [whisper_dictation](https://github.com/themanyone/whisper_dictation) | ![GitHub stars](https://img.shields.io/github/stars/themanyone/whisper_dictation?style=flat-square) | Voice dictation tool |
 | [WhisperGUI](https://github.com/ADT109119/WhisperGUI) | ![GitHub stars](https://img.shields.io/github/stars/ADT109119/WhisperGUI?style=flat-square) | Simple GUI |
+| [WhisPaste](https://github.com/whispaste/whispaste) | ![GitHub stars](https://img.shields.io/github/stars/whispaste/whispaste?style=flat-square) | System-wide hotkey dictation, pastes at the cursor. Local whisper.cpp by default, MIT-licensed |
 
 ### Linux
 


### PR DESCRIPTION
Adds WhisPaste, a free and open-source (MIT) system-wide hotkey dictation app for Windows, macOS and Linux. Press a hotkey, speak, and the transcript is pasted directly at the cursor in any app. Runs whisper.cpp locally by default (offline, no account required); cloud providers are available but opt-in.

- GitHub: https://github.com/whispaste/whispaste
- Website: https://whispaste.de

Added to the "Cross-Platform" quick-nav list and the "Cross-Platform Desktop Applications" table under By Platform, matching the existing entry style/format.