### PR TITLE
Add ScribeDrop to Windows desktop applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Applications that work on Linux, macOS, and Windows:
 
 #### Desktop Applications
 - **[AI Transcription](https://apps.microsoft.com/detail/9p7f1j2svk3g)** - Microsoft Store app
+- **[ScribeDrop](https://github.com/DJsluxx/scribedrop)** - Drag-and-drop GUI for faster-whisper. Queues files or folders, outputs .txt/.srt/.vtt, runs on NVIDIA GPU or CPU. Offline after the model download. MIT.
 - **[Tania Dictée](https://github.com/elboKazQC/tania-dictee)** - Push-to-talk dictation (F6), pastes directly into the focused app. Runs Whisper offline, no cloud. Handles French-Quebec franglais. MIT.
 - **[Whisper Typing for Windows](https://whispertyping.com/download)** - Desktop voice typing
 


### PR DESCRIPTION
Adds **ScribeDrop** to `By Platform > Windows > Desktop Applications`, in alphabetical position.

A free, MIT-licensed Windows GUI for [faster-whisper](https://github.com/SYSTRAN/faster-whisper). Drag audio or video files (or whole folders) onto the window, pick model size, language and output formats, and get `.txt`, `.srt` and `.vtt` written next to the source. It has a proper queue with per-file progress and a cancel that works mid-file, uses an NVIDIA GPU when one is present and the CPU when not, and states which in the status line rather than silently falling back.

Audio is never uploaded — no account, no server, no telemetry. Model weights download from Hugging Face on first use of each size; after that the model is opened with `local_files_only=True` so a cached run makes no network requests at all.

The Windows section is currently all dictation and voice-typing tools. This one is file-in/subtitle-out, which is a different job, so it seemed like a genuine gap rather than a duplicate. It would also fit `By Use Case > Subtitles & Captioning` — happy to add it there instead or as well if you prefer, just say which.

I followed the formatting of the recently merged Tania Dictée entry (no stars badge). **Disclosure:** I am the author and this is a new project with 0 stars, so please treat it as a suggestion rather than a claim to a Popular Picks slot. If you'd rather wait for it to have a track record, that's completely fair and I won't re-open.
