### PR TITLE
Add Dictámelo to Mac and Windows desktop apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Applications that work on Linux, macOS, and Windows:
 ### macOS
 
 #### Desktop Applications
+- **[Dictámelo](https://github.com/sarrazola/dictamelo)** ![GitHub stars](https://img.shields.io/github/stars/sarrazola/dictamelo?style=flat-square) - MIT-licensed hold-to-talk dictation with local Whisper models and optional cloud providers (Apple Silicon)
 - **[SuperWhisper](https://superwhisper.com/)** - Premium Mac voice-to-text app
 - **[OpenSuperWhisper](https://github.com/Starmel/OpenSuperWhisper)** ![GitHub stars](https://img.shields.io/github/stars/Starmel/OpenSuperWhisper?style=flat-square) - Open-source Mac app
 - **[WhisperKit](https://github.com/argmaxinc/WhisperKit)** ![GitHub stars](https://img.shields.io/github/stars/argmaxinc/WhisperKit?style=flat-square) - Native macOS implementation
@@ -216,6 +217,7 @@ Applications that work on Linux, macOS, and Windows:
 ### Windows
 
 #### Desktop Applications
+- **[Dictámelo](https://github.com/sarrazola/dictamelo)** ![GitHub stars](https://img.shields.io/github/stars/sarrazola/dictamelo?style=flat-square) - MIT-licensed hold-to-talk dictation with local Whisper models and optional cloud providers (x64 and ARM64)
 - **[AI Transcription](https://apps.microsoft.com/detail/9p7f1j2svk3g)** - Microsoft Store app
 - **[Tania Dictée](https://github.com/elboKazQC/tania-dictee)** - Push-to-talk dictation (F6), pastes directly into the focused app. Runs Whisper offline, no cloud. Handles French-Quebec franglais. MIT.
 - **[Whisper Typing for Windows](https://whispertyping.com/download)** - Desktop voice typing


### PR DESCRIPTION
Adds Dictámelo to the macOS and Windows desktop sections

I am its developer
The app uses a hold-to-talk shortcut and pastes the transcription into the active field, with local Whisper downloads and optional cloud providers

The entries identify the released architectures explicitly: Apple Silicon for macOS, x64 and ARM64 for Windows
The source is MIT licensed and local transcription requires no account or API key after a model download

Validation: checked the public README, license, model documentation and v1.0.0 release assets

Source: https://github.com/sarrazola/dictamelo
Release: https://github.com/sarrazola/dictamelo/releases/tag/v1.0.0
